### PR TITLE
Fix possible crash calling `RNWootric.configureWithClientID()` on android

### DIFF
--- a/android/src/main/java/com/reactlibrary/RNWootricModule.java
+++ b/android/src/main/java/com/reactlibrary/RNWootricModule.java
@@ -70,7 +70,7 @@ public class RNWootricModule extends ReactContextBaseJavaModule {
 
       wootric = Wootric.init(currentActivity, clientId, accountToken);
 
-      promise.resolve();
+      promise.resolve("");
     } catch (Exception e) {
       promise.reject(E_WOOTRIC_INIT_ERROR, e);
     }

--- a/android/src/main/java/com/reactlibrary/RNWootricModule.java
+++ b/android/src/main/java/com/reactlibrary/RNWootricModule.java
@@ -70,7 +70,7 @@ public class RNWootricModule extends ReactContextBaseJavaModule {
 
       wootric = Wootric.init(currentActivity, clientId, accountToken);
 
-      promise.resolve(wootric);
+      promise.resolve();
     } catch (Exception e) {
       promise.reject(E_WOOTRIC_INIT_ERROR, e);
     }

--- a/android/src/main/java/com/reactlibrary/RNWootricModule.java
+++ b/android/src/main/java/com/reactlibrary/RNWootricModule.java
@@ -1,5 +1,8 @@
 package com.reactlibrary;
 
+import android.app.Activity;
+
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
@@ -14,6 +17,8 @@ public class RNWootricModule extends ReactContextBaseJavaModule {
 
   private final ReactApplicationContext reactContext;
   private Wootric wootric;
+  private static final String E_ACTIVITY_DOES_NOT_EXIST = "E_ACTIVITY_DOES_NOT_EXIST";
+  private static final String E_WOOTRIC_INIT_ERROR = "E_WOOTRIC_INIT_ERROR";
 
   public RNWootricModule(ReactApplicationContext reactContext) {
     super(reactContext);
@@ -53,8 +58,22 @@ public class RNWootricModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void configureWithClientID(String clientId, String accountToken) {
-    wootric = Wootric.init(getCurrentActivity(), clientId, accountToken);
+  public void configureWithClientID(String clientId, String accountToken, Promise promise) {
+    try {
+      Activity currentActivity = getCurrentActivity();
+
+      // Check if activity is null
+      if (currentActivity == null) {
+        promise.reject(E_ACTIVITY_DOES_NOT_EXIST, "Activity doesn't exist");
+        return;
+      }
+
+      wootric = Wootric.init(currentActivity, clientId, accountToken);
+
+      promise.resolve(wootric);
+    } catch (Exception e) {
+      promise.reject(E_WOOTRIC_INIT_ERROR, e);
+    }
   }
 
   @ReactMethod


### PR DESCRIPTION
### Changes
- Fix issue [#11](https://github.com/Wootric/react-native-wootric/issues/11)

**Obs:** The `configureWithClientID` method should be called as a promise on javascript side:
`configureWithClientID(...).then(...)` or `await configureWithClientID(...)`